### PR TITLE
Fix/QB-2405: Fix typed and parse func

### DIFF
--- a/types/events.go
+++ b/types/events.go
@@ -83,7 +83,7 @@ func TypedEventToEvent(tev proto.Message) (Event, error) {
 		return Event{}, err
 	}
 
-	var attrMap map[string]json.RawMessage
+	var attrMap map[string]interface{}
 	err = json.Unmarshal(evtJSON, &attrMap)
 	if err != nil {
 		return Event{}, err
@@ -94,15 +94,11 @@ func TypedEventToEvent(tev proto.Message) (Event, error) {
 	slices.Sort(keys)
 
 	attrs := make([]abci.EventAttribute, 0, len(attrMap))
-
 	for _, k := range keys {
 		v := attrMap[k]
-		if v[0] == '"' {
-			v = v[1 : len(v)-1]
-		}
 		attrs = append(attrs, abci.EventAttribute{
 			Key:   k,
-			Value: string(v),
+			Value: fmt.Sprintf("%v", v),
 		})
 	}
 
@@ -131,9 +127,9 @@ func ParseTypedEvent(event abci.Event) (proto.Message, error) {
 		return nil, fmt.Errorf("%q does not implement proto.Message", event.Type)
 	}
 
-	attrMap := make(map[string]json.RawMessage)
+	attrMap := make(map[string]interface{})
 	for _, attr := range event.Attributes {
-		attrMap[attr.Key] = json.RawMessage(attr.Value)
+		attrMap[attr.Key] = attr.Value
 	}
 
 	attrBytes, err := json.Marshal(attrMap)


### PR DESCRIPTION
In continuation of:
https://github.com/stratosnet/cosmos-sdk/pull/6
https://github.com/stratosnet/cosmos-sdk/pull/7

Working more stable as in case of `[]` it case an error during parsing as it is not escaped. Currently, it will not store as json value, it will be a stringified value of any type. It ok parsed after.
![Screenshot 2024-01-25 at 17 09 40](https://github.com/stratosnet/cosmos-sdk/assets/121880388/913c11e9-e7f5-431c-a214-6e0d3eb05ea3)
![Screenshot 2024-01-25 at 17 10 06](https://github.com/stratosnet/cosmos-sdk/assets/121880388/bbfa9b78-d6d1-4bef-855c-ac54e97bfd9a)

I will remove a draft when evm will be fully tested.
